### PR TITLE
Feature/sandbox str for jp region

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'webmock'
+gem 'minitest'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,29 @@
+PATH
+  remote: .
+  specs:
+    pay_with_amazon (1.1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    hashdiff (0.3.0)
+    minitest (5.9.0)
+    safe_yaml (1.0.4)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  minitest
+  pay_with_amazon!
+  webmock
+
+BUNDLED WITH
+   1.11.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+task :default => :spec

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "pay_with_amazon"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/pay_with_amazon/login.rb
+++ b/lib/pay_with_amazon/login.rb
@@ -25,7 +25,7 @@ module PayWithAmazon
       @region = region
       @endpoint = region_hash[@region]
       @sandbox = sandbox
-      @sandbox_str = @sandbox ? "api.sandbox" : "api"
+      @sandbox_str = @sandbox ? sandbox_hash[@region] : "api"
     end
 
     # This method will validate the access token and
@@ -70,6 +70,16 @@ module PayWithAmazon
       }
     end
 
-  end
+    def sandbox_hash
+      {
+        :jp => 'api-sandbox',
+        :uk => 'api.sandbox',
+        :de => 'api.sandbox',
+        :eu => 'api.sandbox',
+        :us => 'api.sandbox',
+        :na => 'api.sandbox'
+      }
+    end
 
+  end
 end

--- a/lib/pay_with_amazon/version.rb
+++ b/lib/pay_with_amazon/version.rb
@@ -1,4 +1,4 @@
 module PayWithAmazon
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
   API_VERSION = "2013-01-01"
 end


### PR DESCRIPTION
Since I started to develop web site to use login and pay with amazon with Ruby On Rails, I could not connect to profile API endpoint of sandbox for jp region.

End point : https://api-sandbox.amazon.co.jp/
This SDK makes it as: https://api.sandbox.amazon.co.jp/

I corrected locally then this works fine. So I would like to merge to your base.

Note: Test environment looks lacked so I tried to prepare and now it can be run with failed.
      I am not sure this test originally passed so I did not check deeply its failed.
